### PR TITLE
Add MIDI player to musician loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -679,6 +679,7 @@
   - PanFlute
   - Ocarina
   - Bagpipe
+  - MidiPlayer
 
 #- type: loadoutGroup
 #  id: MusicianJobTrinkets

--- a/Resources/Prototypes/Loadouts/Miscellaneous/instruments.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/instruments.yml
@@ -166,3 +166,9 @@
   storage:
     back:
     - BagpipeInstrument
+
+- type: loadout
+  id: MidiPlayer
+  storage:
+    back:
+    - midi_player_w


### PR DESCRIPTION
## Summary
- add the Colorfly-NT MIDI player as a selectable musician instrument loadout
- include the new loadout in the existing Instruments loadout group

## Testing
- verified YAML references for the new `MidiPlayer` loadout and `midi_player_w` entity ID
