### PR TITLE
Add neck break chance to salto

### DIFF
--- a/Content.Shared/Movement/Components/JumpAbilityComponent.cs
+++ b/Content.Shared/Movement/Components/JumpAbilityComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.Damage;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -61,6 +62,36 @@ public sealed partial class JumpAbilityComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public LocId? JumpFailedPopup = "jump-ability-failure";
+
+    /// <summary>
+    /// Chance that a successful jump/somersault snaps the performer's neck.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float NeckBreakChance = 0.05f;
+
+    /// <summary>
+    /// Damage dealt when the performer botches the jump and snaps their neck.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier NeckBreakDamage = new()
+    {
+        DamageDict = new()
+        {
+            { "Blunt", 200.0 },
+        },
+    };
+
+    /// <summary>
+    /// Knockdown time applied on a neck-breaking jump failure.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan NeckBreakKnockdown = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Popup shown when the jump snaps the performer's neck.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? NeckBreakPopup = "jump-ability-neck-break";
 }
 
 public sealed partial class GravityJumpEvent : InstantActionEvent;

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Cloning.Events;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
@@ -8,6 +9,8 @@ using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Random;
 using Robust.Shared.Physics.Events;
 
 namespace Content.Shared.Movement.Systems;
@@ -21,6 +24,9 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
     [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private StandingStateSystem _standing = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -91,7 +97,21 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
             Dirty(entity.Owner, leaperComp);
         }
 
+        TryBreakNeckOnJump(entity, args.Performer);
+
         args.Handled = true;
+    }
+
+    private void TryBreakNeckOnJump(Entity<JumpAbilityComponent> entity, EntityUid performer)
+    {
+        if (!_net.IsServer || entity.Comp.NeckBreakChance <= 0f || !_random.Prob(entity.Comp.NeckBreakChance))
+            return;
+
+        _damageable.TryChangeDamage(performer, entity.Comp.NeckBreakDamage, ignoreResistances: true, origin: performer);
+        _stun.TryKnockdown(performer, entity.Comp.NeckBreakKnockdown, force: true);
+
+        if (entity.Comp.NeckBreakPopup != null)
+            _popup.PopupEntity(Loc.GetString(entity.Comp.NeckBreakPopup.Value, ("performer", performer)), performer, PopupType.LargeCaution);
     }
 
     private void OnClone(Entity<JumpAbilityComponent> ent, ref CloningEvent args)
@@ -108,6 +128,10 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
         targetComp.CollideKnockdown = ent.Comp.CollideKnockdown;
         targetComp.JumpSound = ent.Comp.JumpSound;
         targetComp.JumpFailedPopup = ent.Comp.JumpFailedPopup;
+        targetComp.NeckBreakChance = ent.Comp.NeckBreakChance;
+        targetComp.NeckBreakDamage = ent.Comp.NeckBreakDamage;
+        targetComp.NeckBreakKnockdown = ent.Comp.NeckBreakKnockdown;
+        targetComp.NeckBreakPopup = ent.Comp.NeckBreakPopup;
         AddComp(args.CloneUid, targetComp, true);
     }
 }

--- a/Resources/Locale/en-US/jump-ability/jump-ability.ftl
+++ b/Resources/Locale/en-US/jump-ability/jump-ability.ftl
@@ -1,1 +1,2 @@
 jump-ability-failure = You cannot jump right now.
+jump-ability-neck-break = {$performer} lands badly and snaps their neck!

--- a/Resources/Locale/ru-RU/jump-ability/jump-ability.ftl
+++ b/Resources/Locale/ru-RU/jump-ability/jump-ability.ftl
@@ -1,1 +1,2 @@
 jump-ability-failure = Вы не можете прыгнуть сейчас.
+jump-ability-neck-break = {$performer} неудачно приземляется и ломает себе шею!


### PR DESCRIPTION
Closes #19.

Добавляет на успешный прыжок/сальто шанс сломать шею:
- настраиваемый шанс через `JumpAbilityComponent.NeckBreakChance` (по умолчанию 5%);
- при неудаче наносится сильный `Blunt`-урон, персонаж падает, показывается локализованный попап;
- эффект выполняется только на сервере, чтобы не ловить клиентскую миспредикцию.

Проверка: `git diff --check`; локальный `dotnet build` недоступен в окружении (нет `dotnet`).